### PR TITLE
Bug fix

### DIFF
--- a/LIPPackageBuilder/app.js
+++ b/LIPPackageBuilder/app.js
@@ -77,15 +77,16 @@ lbs.apploader.register('LIPPackageBuilder', function () {
         }
         
 
+        var checkIfVbaLoaded = false;
         // Navbar function to change tab
         vm.showTab = function(t){
-            try{
-                if (t == 'vba'){
-                    vm.getVbaComponents();
-                }
-                vm.activeTab(t);
-                
+        try{
+            if (t == 'vba' && checkIfVbaLoaded == false){
+                vm.getVbaComponents();
+                checkIfVbaLoaded = true;
             }
+          vm.activeTab(t);
+        }
             catch(e){alert(e);}
         }
         


### PR DESCRIPTION
When switching tabs from VBA to another, selected VBA are not selected anymore when you switch back (but is included in package anyway)